### PR TITLE
Add text on undocumented errors to OAS definition

### DIFF
--- a/code/API_definitions/kyc-age-verification.yaml
+++ b/code/API_definitions/kyc-age-verification.yaml
@@ -41,7 +41,11 @@ info:
     - If the API call contains a formatting or other any other syntactic error, a `400 INVALID_ARGUMENT` error is returned.
     - If the network subscription cannot be identified from the provided parameters (e.g. the subscription identifier is not associated with any customer of the CSP), a `404 IDENTIFIER_NOT_FOUND` error is returned.
     - If the API consumer has a valid access token that does not have the required scope to obtain Age Verification information for the specified network subscription, then a `403 PERMISSION_DENIED` error is returned.
-    - Other errors may be returned as specified below.
+
+    ### Additional CAMARA error responses
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
+    As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
 
     # Identifying the phone number from the access token
 


### PR DESCRIPTION
Add text on undocumented errors to OAS definition

#### What type of PR is this?

* documentation

#### What this PR does / why we need it:
Adds mandatory text on undocumented errors to the OAS info.description section as defined [here](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Design-Guide.md#33-error-responses---mandatory-template-for-infodescription-in-camara-api-specs).



<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #9 , or `Fixes (paste link of issue)`. -->

Fixes #9 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



