### PR TITLE
Delete the release r1.1 from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Sandbox API Repository to describe, develop, document, and test the KnowYourCust
 ## Release Information
 
 * Note: Please be aware that the project will have updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. For best results, use the latest available release.
-* **NEW: Pre-release of CAMARA KYC Age Verification is [r1.1](https://github.com/camaraproject/KnowYourCustomerAgeVerification/tree/r1.1)**. The Release Tag is [r1.1](https://github.com/camaraproject/KnowYourCustomerAgeVerification/releases/tag/r1.1).
 * **Releases of the CAMARA KYC Age Verification API until Spring25 are available in [KnowYourCustomer](https://github.com/camaraproject/KnowYourCustomer).**
 * For changes see [CHANGELOG.md](https://github.com/camaraproject/KnowYourCustomerAgeVerification/blob/main/CHANGELOG.md)    
 


### PR DESCRIPTION
#### What type of PR is this?

* correction
* repository management

#### What this PR does / why we need it:

API definition in r1.1 can't be used due to syntax errors, so, r1.1 needs to be made unavailable by deleting r1.1 information from README.md.

#### Which issue(s) this PR fixes:

Fixes no issues directly, but related to Issue #16

#### Special notes for reviewers:

Correct API definition r1.2 to be created soon

#### Changelog input

```
 release-note

```

#### Additional documentation 

