### PR TITLE
Prepare kyc-ageverification pre-release-rc

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,31 +10,31 @@ repository:
   # Options: independent (default) | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Fall25
+  meta_release: Sync26
 
   # Target CAMARA release tag.
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.3
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.3
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: kyc-age-verification
-    target_api_version: 0.2.1
-    target_api_status: public
+    target_api_version: 0.3.0
+    target_api_status: rc
     main_contacts:
       - ToshiWakayama-KDDI
       - fernandopradocabrillo

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,7 +16,7 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r2.0
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,7 +16,7 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r2.1
+  target_release_tag: r2.0
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release


### PR DESCRIPTION
What type of PR is this?

    subproject management

What this PR does / why we need it:

    Update release-plan.yaml for the kyc-ageverification release candidate preparation.

Which issue(s) this PR fixes:

N/A - no upstream issue.
Special notes for reviewers:

N/A